### PR TITLE
feat(variants): добавить вариант buildlab_scout (ESP32-S3-Zero + E22-900M30S + u-blox GNSS)

### DIFF
--- a/variants/buildlab_scout/BuildLabScoutBoard.cpp
+++ b/variants/buildlab_scout/BuildLabScoutBoard.cpp
@@ -1,0 +1,28 @@
+#include "BuildLabScoutBoard.h"
+
+void BuildLabScoutBoard::begin() {
+  ESP32Board::begin();
+
+#ifdef PIN_GPS_EN
+  // MeshCore's generic UART-GPS init (initBasicGPS) never drives PIN_GPS_EN,
+  // so the module would stay off. Drive it active-high (matches Meshtastic GPS_EN_ACTIVE 1).
+  pinMode(PIN_GPS_EN, OUTPUT);
+  digitalWrite(PIN_GPS_EN, HIGH);
+#endif
+}
+
+uint16_t BuildLabScoutBoard::getBattMilliVolts() {
+#ifdef PIN_VBAT_READ
+  analogReadResolution(12);
+
+  uint32_t raw = 0;
+  for (int i = 0; i < 8; i++) {
+    raw += analogReadMilliVolts(PIN_VBAT_READ);
+  }
+  raw = raw / 8;
+
+  return (uint16_t)(raw * BATTERY_ADC_MULTIPLIER);
+#else
+  return 0;  // not supported
+#endif
+}

--- a/variants/buildlab_scout/BuildLabScoutBoard.h
+++ b/variants/buildlab_scout/BuildLabScoutBoard.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <Arduino.h>
+#include <helpers/ESP32Board.h>
+
+// Battery voltage-divider ratio. Ported from Meshtastic (ADC_MULTIPLIER 2.08).
+#ifndef BATTERY_ADC_MULTIPLIER
+  #define BATTERY_ADC_MULTIPLIER 2.0f
+#endif
+
+class BuildLabScoutBoard : public ESP32Board {
+public:
+  void begin();
+  uint16_t getBattMilliVolts() override;
+  const char* getManufacturerName() const override { return "BuildLab Scout"; }
+};

--- a/variants/buildlab_scout/platformio.ini
+++ b/variants/buildlab_scout/platformio.ini
@@ -1,0 +1,155 @@
+[BuildLab_Scout]
+extends = esp32_base
+; BuildLab Scout: Waveshare ESP32-S3-Zero + E22-900M30S (ported from Meshtastic
+; esp32s3-zero_E22_900m_30S). Hardware differs from the original vendor board.
+board = esp32-s3-zero
+build_flags =
+  ${esp32_base.build_flags}
+  ${sensor_base.build_flags}
+  -I variants/buildlab_scout
+  -D BUILDLAB_SCOUT
+  -D P_LORA_DIO_1=45
+  -D P_LORA_NSS=18
+  -D P_LORA_RESET=41
+  -D P_LORA_BUSY=42
+  -D P_LORA_SCLK=38
+  -D P_LORA_MISO=40
+  -D P_LORA_MOSI=39
+  -D SX126X_TXEN=3
+  -D SX126X_RXEN=17
+  -D PIN_VBAT_READ=1
+  -D PIN_USER_BTN=6
+  -D PIN_BUZZER=10
+  -D PIN_BOARD_SDA=11
+  -D PIN_BOARD_SCL=12
+  -D BATTERY_ADC_MULTIPLIER=2.08f
+
+  ; GPS (u-blox): ESP RX=GPIO7 @38400; EN=GPIO9 driven in BuildLabScoutBoard::begin().
+  -D PIN_GPS_TX=7
+  -D PIN_GPS_RX=8
+  -D PIN_GPS_EN=9
+  -D GPS_BAUD_RATE=38400
+  -D ENV_SKIP_GPS_DETECT=1
+  -D UI_SENSORS_PAGE=1   ; страница сенсоров на дисплее (нужна при включённых сенсорах в этом форке)
+
+  ; E22-900M30S uses external TXEN/RXEN RF switch -> DIO2_AS_RF_SWITCH NOT set.
+  -D SX126X_DIO3_TCXO_VOLTAGE=1.8
+  -D SX126X_CURRENT_LIMIT=140
+  -D USE_SX1262
+  -D RADIO_CLASS=CustomSX1262
+  -D WRAPPER_CLASS=CustomSX1262Wrapper
+  -D LORA_TX_POWER=22
+  -D SX126X_RX_BOOSTED_GAIN=1
+build_src_filter = ${esp32_base.build_src_filter}
+  +<../variants/buildlab_scout>
+  +<helpers/sensors>
+  +<helpers/ui/buzzer.cpp>
+lib_deps =
+  ${esp32_base.lib_deps}
+  ${sensor_base.lib_deps}
+  adafruit/Adafruit SSD1306 @ ^2.5.13
+  end2endzone/NonBlockingRTTTL@^1.3.0
+
+; === BuildLab Scout environments ===
+[env:BuildLab_Scout_repeater]
+extends = BuildLab_Scout
+board_build.partitions = huge_app.csv   ; 3MB app (без OTA) — south_edition не влезает в дефолтные 1.25MB
+build_flags =
+  ${BuildLab_Scout.build_flags}
+  -D DISPLAY_CLASS=SSD1306Display
+  -D ADVERT_NAME='"Scout Repeater"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D MAX_NEIGHBOURS=50
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${BuildLab_Scout.build_src_filter}
+  +<helpers/ui/SSD1306Display.cpp>
+  +<../examples/simple_repeater>
+lib_deps =
+  ${BuildLab_Scout.lib_deps}
+  ${esp32_ota.lib_deps}
+
+[env:BuildLab_Scout_terminal_chat]
+extends = BuildLab_Scout
+build_flags =
+  ${BuildLab_Scout.build_flags}
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=1
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${BuildLab_Scout.build_src_filter}
+  +<../examples/simple_secure_chat/main.cpp>
+lib_deps =
+  ${BuildLab_Scout.lib_deps}
+  densaugeo/base64 @ ~1.4.0
+
+[env:BuildLab_Scout_room_server]
+extends = BuildLab_Scout
+board_build.partitions = huge_app.csv   ; 3MB app (без OTA) — south_edition не влезает в дефолтные 1.25MB
+build_flags =
+  ${BuildLab_Scout.build_flags}
+  -D DISPLAY_CLASS=SSD1306Display
+  -D ADVERT_NAME='"Scout Room"'
+  -D ADVERT_LAT=0.0
+  -D ADVERT_LON=0.0
+  -D ADMIN_PASSWORD='"password"'
+  -D ROOM_PASSWORD='"hello"'
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+build_src_filter = ${BuildLab_Scout.build_src_filter}
+  +<helpers/ui/SSD1306Display.cpp>
+  +<../examples/simple_room_server>
+lib_deps =
+  ${BuildLab_Scout.lib_deps}
+  ${esp32_ota.lib_deps}
+
+[env:BuildLab_Scout_companion_radio_usb]
+extends = BuildLab_Scout
+build_flags =
+  ${BuildLab_Scout.build_flags}
+  -I examples/companion_radio/ui-new
+  -D DISPLAY_CLASS=SSD1306Display
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=40
+  -D WITH_COMPANION_CLI
+  -DDISPLAY_TZ=\"MSK-3\"
+; NOTE: DO NOT ENABLE -->  -D MESH_PACKET_LOGGING=1
+; NOTE: DO NOT ENABLE -->  -D MESH_DEBUG=1
+  -D CYRILLIC_SUPPORT=1
+build_src_filter = ${BuildLab_Scout.build_src_filter}
+  +<helpers/ui/SSD1306Display.cpp>
+  +<helpers/ui/MomentaryButton.cpp>
+  +<../examples/companion_radio/*.cpp>
+  +<../examples/companion_radio/ui-new/*.cpp>
+lib_deps =
+  ${BuildLab_Scout.lib_deps}
+  densaugeo/base64 @ ~1.4.0
+
+[env:BuildLab_Scout_companion_radio_ble]
+extends = BuildLab_Scout
+board_build.partitions = huge_app.csv   ; 3MB app (без OTA) — south_edition не влезает в дефолтные 1.25MB
+build_flags =
+  ${BuildLab_Scout.build_flags}
+  -I examples/companion_radio/ui-new
+  -D DISPLAY_CLASS=SSD1306Display
+  -D MAX_CONTACTS=350
+  -D MAX_GROUP_CHANNELS=40
+  -D WITH_COMPANION_CLI
+  -DDISPLAY_TZ=\"MSK-3\"
+  -D BLE_PIN_CODE=123456
+  -D BLE_DEBUG_LOGGING=1
+  -D OFFLINE_QUEUE_SIZE=256
+;  -D MESH_PACKET_LOGGING=1
+;  -D MESH_DEBUG=1
+  -D CYRILLIC_SUPPORT=1
+build_src_filter = ${BuildLab_Scout.build_src_filter}
+  +<helpers/esp32/*.cpp>
+  +<helpers/ui/SSD1306Display.cpp>
+  +<helpers/ui/MomentaryButton.cpp>
+  +<../examples/companion_radio/*.cpp>
+  +<../examples/companion_radio/ui-new/*.cpp>
+lib_deps =
+  ${BuildLab_Scout.lib_deps}
+  densaugeo/base64 @ ~1.4.0

--- a/variants/buildlab_scout/target.cpp
+++ b/variants/buildlab_scout/target.cpp
@@ -1,0 +1,60 @@
+#include <Arduino.h>
+#include "target.h"
+
+BuildLabScoutBoard board;
+
+#if defined(P_LORA_SCLK)
+  static SPIClass spi;
+  RADIO_CLASS radio = new Module(P_LORA_NSS, P_LORA_DIO_1, P_LORA_RESET, P_LORA_BUSY, spi);
+#else
+  RADIO_CLASS radio = new Module(P_LORA_NSS, P_LORA_DIO_1, P_LORA_RESET, P_LORA_BUSY);
+#endif
+
+WRAPPER_CLASS radio_driver(radio, board);
+
+ESP32RTCClock fallback_clock;
+AutoDiscoverRTCClock rtc_clock(fallback_clock);
+
+#if ENV_INCLUDE_GPS
+  #include <helpers/sensors/MicroNMEALocationProvider.h>
+  MicroNMEALocationProvider nmea = MicroNMEALocationProvider(Serial1, &rtc_clock);
+  EnvironmentSensorManager sensors = EnvironmentSensorManager(nmea);
+#else
+  EnvironmentSensorManager sensors;
+#endif
+
+#ifdef DISPLAY_CLASS
+  DISPLAY_CLASS display;
+  MomentaryButton user_btn(PIN_USER_BTN, 1000, true);
+#endif
+
+bool radio_init() {
+  fallback_clock.begin();
+  rtc_clock.begin(Wire);
+
+#if defined(P_LORA_SCLK)
+  return radio.std_init(&spi);
+#else
+  return radio.std_init();
+#endif
+}
+
+uint32_t radio_get_rng_seed() {
+  return radio.random(0x7FFFFFFF);
+}
+
+void radio_set_params(float freq, float bw, uint8_t sf, uint8_t cr) {
+  radio.setFrequency(freq);
+  radio.setSpreadingFactor(sf);
+  radio.setBandwidth(bw);
+  radio.setCodingRate(cr);
+}
+
+void radio_set_tx_power(int8_t dbm) {
+  radio.setOutputPower(dbm);
+}
+
+mesh::LocalIdentity radio_new_identity() {
+  RadioNoiseListener rng(radio);
+  return mesh::LocalIdentity(&rng);  // create new random identity
+}

--- a/variants/buildlab_scout/target.h
+++ b/variants/buildlab_scout/target.h
@@ -1,0 +1,42 @@
+#pragma once
+// POSIX timezone string for the clock display page.
+// Examples: "UTC0"           UTC
+//           "MSK-3"          Moscow (UTC+3)
+//           "EET-2"          Eastern Europe (UTC+2)
+//           "CET-1CEST,M3.5.0,M10.5.0/3"  Central Europe with DST
+// Override in platformio.ini: -DDISPLAY_TZ="MSK-3"
+// See: https://www.gnu.org/software/libc/manual/html_node/TZ-Variable.html
+#ifndef DISPLAY_TZ
+#  define DISPLAY_TZ  "UTC0"
+#endif
+
+
+#define RADIOLIB_STATIC_ONLY 1
+#include <RadioLib.h>
+#include <helpers/radiolib/RadioLibWrappers.h>
+#include <helpers/ESP32Board.h>
+#include "BuildLabScoutBoard.h"
+#include <helpers/radiolib/CustomSX1262Wrapper.h>
+#include <helpers/AutoDiscoverRTCClock.h>
+#include <helpers/SensorManager.h>
+#include <helpers/sensors/EnvironmentSensorManager.h>
+#ifdef DISPLAY_CLASS
+  #include <helpers/ui/SSD1306Display.h>
+  #include <helpers/ui/MomentaryButton.h>
+#endif
+
+extern BuildLabScoutBoard board;
+extern WRAPPER_CLASS radio_driver;
+extern AutoDiscoverRTCClock rtc_clock;
+extern EnvironmentSensorManager sensors;
+
+#ifdef DISPLAY_CLASS
+  extern DISPLAY_CLASS display;
+  extern MomentaryButton user_btn;
+#endif
+
+bool radio_init();
+uint32_t radio_get_rng_seed();
+void radio_set_params(float freq, float bw, uint8_t sf, uint8_t cr);
+void radio_set_tx_power(int8_t dbm);
+mesh::LocalIdentity radio_new_identity();


### PR DESCRIPTION
﻿### Что добавлено

Новый board-вариант `variants/buildlab_scout/` для носимой LoRa-ноды **BuildLab Scout**:

| Компонент | Модель |
|-----------|--------|
| MCU       | Waveshare ESP32-S3-Zero |
| Радио     | E22-900M30S (SX1262, 30 дБм) |
| GNSS      | u-blox M10050 (UART, 38400 бод) |
| Дисплей   | SSD1306 (I2C) |

Пины перенесены из Meshtastic-варианта `esp32s3-zero_E22_900m_30S`  https://mrekin.duckdns.org/flasher/ и проверены на живом железе.

### Что НЕ сломано

- Вариант `variants/ebyte_eora_s3/` **не тронут** — (брался как пример) все существующие env'ы работают без изменений.
- Новые env'ы имеют уникальные имена `BuildLab_Scout_*` — конфликта имён нет.
- CI (`pr-build-check.yml`) использует glob `variants/**` — подхватит новый вариант автоматически.

### Ключевые технические решения

- `board = esp32-s3-zero` — стандартная PlatformIO-платформа, кастомный `board.json` не нужен.
- RF-переключатель E22-900M30S: внешний (`SX126X_TXEN=3` / `SX126X_RXEN=17`), DIO2_AS_RF_SWITCH отключён.
- Кастомный класс `BuildLabScoutBoard` (наследник `ESP32Board`):
  - `begin()` — подтягивает `PIN_GPS_EN` (GPIO9) HIGH (стандартный `initBasicGPS` MeshCore этого не делает).
  - `getBattMilliVolts()` — усреднение по 8 измерениям АЦП, множитель 2.08 (из Meshtastic).
- `companion_radio_ble` — партиция `huge_app.csv` (3 МБ app), south_edition не помещается в дефолтные 1.25 МБ.

### Результаты сборки

Проверено: `pio run -e BuildLab_Scout_companion_radio_ble` (наиболее тяжёлый env):

```
Flash: 41.8% (1 314 361 / 3 145 728 байт)  ✅ вмещается в huge_app.csv
RAM:   57.2% (187 316 / 327 680 байт)       ✅
Статус: SUCCESS
```

### Env'ы

| Env | Назначение |
|-----|-----------|
| `BuildLab_Scout_Repeater` | Ретранслятор с дисплеем |
| `BuildLab_Scout_terminal_chat` | Терминальный чат |
| `BuildLab_Scout_room_server` | Room-сервер |
| `BuildLab_Scout_companion_radio_usb` | Companion radio (USB) |
| `BuildLab_Scout_companion_radio_ble` | Companion radio (BLE, huge_app) |

### Состав PR

```
variants/buildlab_scout/
├── BuildLabScoutBoard.h/.cpp   ← кастомный класс платы
├── target.h / target.cpp       ← стандартный target для South Edition
└── platformio.ini              ← все 5 env'ов
```
