### PR TITLE
Fix CYRILLIC_SUPPORT for some displays

### DIFF
--- a/src/helpers/ui/E213Display.cpp
+++ b/src/helpers/ui/E213Display.cpp
@@ -167,12 +167,7 @@ void E213Display::setCursor(int x, int y) {
 
 void E213Display::print(const char *str) {
   display_crc.update<char>(str, strlen(str));
-#ifdef CYRILLIC_SUPPORT
-  char cp[256];
-  translateUTF8ToBlocks(cp, str, sizeof(cp));
-  str = cp;
-#endif
-    display->print(str);
+  display->print(str);
 }
 
 void E213Display::fillRect(int x, int y, int w, int h) {
@@ -188,7 +183,7 @@ void E213Display::drawRect(int x, int y, int w, int h) {
   display_crc.update<int>(y);
   display_crc.update<int>(w);
   display_crc.update<int>(h);
-    display->drawRect(x, y, w, h, BLACK);
+  display->drawRect(x, y, w, h, BLACK);
 }
 
 void E213Display::drawXbm(int x, int y, const uint8_t *bits, int w, int h) {
@@ -219,11 +214,6 @@ void E213Display::drawXbm(int x, int y, const uint8_t *bits, int w, int h) {
 }
 
 uint16_t E213Display::getTextWidth(const char *str) {
-#ifdef CYRILLIC_SUPPORT
-  char cp[256];
-  translateUTF8ToBlocks(cp, str, sizeof(cp));
-  str = cp;
-#endif
   int16_t x1, y1;
   uint16_t w, h;
   display->getTextBounds(str, 0, 0, &x1, &y1, &w, &h);

--- a/src/helpers/ui/E290Display.cpp
+++ b/src/helpers/ui/E290Display.cpp
@@ -118,11 +118,6 @@ void E290Display::setCursor(int x, int y) {
 
 void E290Display::print(const char *str) {
   display_crc.update<char>(str, strlen(str));
-#ifdef CYRILLIC_SUPPORT
-  char cp[256];
-  translateUTF8ToBlocks(cp, str, sizeof(cp));
-  str = cp;
-#endif
   display.print(str);
 }
 
@@ -170,11 +165,6 @@ void E290Display::drawXbm(int x, int y, const uint8_t *bits, int w, int h) {
 }
 
 uint16_t E290Display::getTextWidth(const char *str) {
-#ifdef CYRILLIC_SUPPORT
-  char cp[256];
-  translateUTF8ToBlocks(cp, str, sizeof(cp));
-  str = cp;
-#endif
   int16_t x1, y1;
   uint16_t w, h;
   display.getTextBounds(str, 0, 0, &x1, &y1, &w, &h);

--- a/src/helpers/ui/SH1106Display.cpp
+++ b/src/helpers/ui/SH1106Display.cpp
@@ -44,9 +44,6 @@ void SH1106Display::startFrame(Color bkg)
 #endif
   display.setTextColor(_color);
   display.setTextSize(1);
-#ifndef CYRILLIC_SUPPORT
-  display.cp437(true); // Use full 256 char 'Code Page 437' font
-#endif
 }
 
 void SH1106Display::setTextSize(int sz)
@@ -75,11 +72,6 @@ void SH1106Display::setCursor(int x, int y)
 
 void SH1106Display::print(const char *str)
 {
-#ifdef CYRILLIC_SUPPORT
-  char cp[256];
-  translateUTF8ToBlocks(cp, str, sizeof(cp));
-  str = cp;
-#endif
   display.print(str);
 }
 
@@ -100,11 +92,6 @@ void SH1106Display::drawXbm(int x, int y, const uint8_t *bits, int w, int h)
 
 uint16_t SH1106Display::getTextWidth(const char *str)
 {
-#ifdef CYRILLIC_SUPPORT
-  char cp[256];
-  translateUTF8ToBlocks(cp, str, sizeof(cp));
-  str = cp;
-#endif
   int16_t x1, y1;
   uint16_t w, h;
   display.getTextBounds(str, 0, 0, &x1, &y1, &w, &h);

--- a/src/helpers/ui/SSD1306Display.cpp
+++ b/src/helpers/ui/SSD1306Display.cpp
@@ -55,9 +55,6 @@ void SSD1306Display::startFrame(Color bkg) {
 #endif
   display.setTextColor(_color);
   display.setTextSize(1);
-#ifndef CYRILLIC_SUPPORT
-  display.cp437(true);         // Use full 256 char 'Code Page 437' font
-#endif
 }
 
 void SSD1306Display::setTextSize(int sz) {
@@ -83,11 +80,6 @@ void SSD1306Display::setCursor(int x, int y) {
 }
 
 void SSD1306Display::print(const char* str) {
-#ifdef CYRILLIC_SUPPORT
-  char cp[256];
-  translateUTF8ToBlocks(cp, str, sizeof(cp));
-  str = cp;
-#endif
   display.print(str);
 }
 
@@ -104,11 +96,6 @@ void SSD1306Display::drawXbm(int x, int y, const uint8_t* bits, int w, int h) {
 }
 
 uint16_t SSD1306Display::getTextWidth(const char* str) {
-#ifdef CYRILLIC_SUPPORT
-  char cp[256];
-  translateUTF8ToBlocks(cp, str, sizeof(cp));
-  str = cp;
-#endif
   int16_t x1, y1;
   uint16_t w, h;
   display.getTextBounds(str, 0, 0, &x1, &y1, &w, &h);

--- a/src/helpers/ui/ST7735Display.cpp
+++ b/src/helpers/ui/ST7735Display.cpp
@@ -90,8 +90,6 @@ void ST7735Display::startFrame(Color bkg) {
   display.setTextSize(1);      // This one affects size of Please wait... message
 #ifdef CYRILLIC_SUPPORT
   display.setFont(&glcdfont6x8);
-#else
-  display.cp437(true);         // Use full 256 char 'Code Page 437' font
 #endif
 }
 
@@ -142,11 +140,6 @@ void ST7735Display::setCursor(int x, int y) {
 }
 
 void ST7735Display::print(const char* str) {
-#ifdef CYRILLIC_SUPPORT
-  char cp[256];
-  translateUTF8ToBlocks(cp, str, sizeof(cp));
-  str = cp;
-#endif
   display.print(str);
 }
 
@@ -163,11 +156,6 @@ void ST7735Display::drawXbm(int x, int y, const uint8_t* bits, int w, int h) {
 }
 
 uint16_t ST7735Display::getTextWidth(const char* str) {
-#ifdef CYRILLIC_SUPPORT
-  char cp[256];
-  translateUTF8ToBlocks(cp, str, sizeof(cp));
-  str = cp;
-#endif
   int16_t x1, y1;
   uint16_t w, h;
   display.getTextBounds(str, 0, 0, &x1, &y1, &w, &h);

--- a/src/helpers/ui/ST7789LCDDisplay.cpp
+++ b/src/helpers/ui/ST7789LCDDisplay.cpp
@@ -83,8 +83,6 @@ void ST7789LCDDisplay::startFrame(Color bkg) {
   display.setTextSize(1 * DISPLAY_SCALE_X); // This one affects size of Please wait... message
 #ifdef CYRILLIC_SUPPORT
   display.setFont(&glcdfont6x8);
-#else
-  display.cp437(true); // Use full 256 char 'Code Page 437' font
 #endif
 }
 
@@ -135,11 +133,6 @@ void ST7789LCDDisplay::setCursor(int x, int y) {
 }
 
 void ST7789LCDDisplay::print(const char* str) {
-#ifdef CYRILLIC_SUPPORT
-  char cp[256];
-  translateUTF8ToBlocks(cp, str, sizeof(cp));
-  str = cp;
-#endif
   display.print(str);
 }
 
@@ -171,11 +164,6 @@ void ST7789LCDDisplay::drawXbm(int x, int y, const uint8_t* bits, int w, int h) 
 }
 
 uint16_t ST7789LCDDisplay::getTextWidth(const char* str) {
-#ifdef CYRILLIC_SUPPORT
-  char cp[256];
-  translateUTF8ToBlocks(cp, str, sizeof(cp));
-  str = cp;
-#endif
   int16_t x1, y1;
   uint16_t w, h;
   display.getTextBounds(str, 0, 0, &x1, &y1, &w, &h);


### PR DESCRIPTION
translateUTF8ToBlocks() уже есть внутри UITask.cpp и не нужен внутри драйверов дисплеев.
Данного преобразования небыло в коде драйверов для eink экранов и потому там всё работало, в отличии от oled/tft.

Протестировано на Heltec V3 (SSD1306) и DIY Nrf+epaper (2.9" weact studios)